### PR TITLE
Improve mobile navigation collapse

### DIFF
--- a/client/views/includes.js
+++ b/client/views/includes.js
@@ -3,3 +3,12 @@ Template.header.helpers({
 		return Experts.findOne({userId:Meteor.userId()});
 	}
 });
+
+Template.header.events({
+    'click .navbar-nav a':function() {
+        var targetButton = document.getElementsByClassName('navbar-toggle')[0];
+        if (window.innerWidth < 768){
+            targetButton.click()
+        }
+    }
+});


### PR DESCRIPTION
This is a small fix for an issue with Bootstrap's collapsing navigation on Meteor.

Before this PR, the navigation wouldn't collapse when going to a different route:

![http://recordit.co/nemaFR.gif](https://cloud.githubusercontent.com/assets/737065/2869351/c36ec41c-d267-11e3-818b-44c022f8f771.gif)

After this fix, clicking the link will also collapse the nav when clicking a `a` tag:

![http://recordit.co/eitvQe.gif](https://cloud.githubusercontent.com/assets/737065/2869352/d115d326-d267-11e3-9a08-00b2ac1a0b94.gif)
