### PR TITLE
Add 'New' badge to newly posted jobs/devs, salary and equity fields and 'co-founder' to constants.js

### DIFF
--- a/client/views/jobs/job.html
+++ b/client/views/jobs/job.html
@@ -5,7 +5,7 @@
 				<div class="panel-body">
 					{{>jobExpiredAlert}}
 					{{#if isInRole 'admin'}}
-					    {{>jobStatusToggle}}  
+					    {{>jobStatusToggle}}
 					{{/if}}
 					{{>jobStatusAlert}}
 					<div class="row">
@@ -47,7 +47,16 @@
 								<i class="fa fa-envelope"></i> {{contact}}
 								<hr>
 							{{/if}}
+							{{#if salary}}
+								<i class="fa fa-usd"></i> {{salary}}
+								<hr>
+							{{/if}}
+							{{#if equity}}
+								<i class="fa fa-pie-chart"></i> {{equity}}
+								<hr>
+							{{/if}}
 							<i class="fa fa-calendar"></i> Posted on {{formatDate createdAt}}
+
 						</div>
 						<div class="col-sm-9">
 							{{#if htmlDescription}}

--- a/client/views/jobs/jobForms.html
+++ b/client/views/jobs/jobForms.html
@@ -50,5 +50,7 @@
     {{> afQuickField name='url' placeholder="External URL of job posting"}}
     {{> afQuickField name="jobtype" firstOption="(Select a Job Type)" options="allowed"}}
     {{> afQuickField name='description' rows=8  placeholder="Tell prospective developers about this position.  What is the project? What will you expect them to know beforehand? Things like that."}}
+		{{> afQuickField name='salary' placeholder="Salary range for the job. Eg.: $90k - $125k"}}
+		{{> afQuickField name='equity' placeholder="Will be any kind of equity offered? Eg.: 0.3% - 1.5%"}}
     {{> afQuickField name='contact' placeholder="email/twitter/whatever for you to be contacted at (your user account email address is not displayed)"}}
 </template>

--- a/client/views/jobs/jobIncludes.html
+++ b/client/views/jobs/jobIncludes.html
@@ -1,4 +1,5 @@
 <template name="jobLabels">
+	{{#if new}}<span class="label label-warning"><i class="fa fa-star"></i> New</span>{{/if}}
 	{{#if remote}}<span class="label label-success"><i class="fa fa-globe"></i> Remote</span>{{/if}}
 	{{#if jobtype}}<span class="label label-default"><i class="fa fa-clock-o"></i> {{jobtype}}</span>{{/if}}
 </template>
@@ -17,7 +18,7 @@
 <template name="jobStatusToggle">
 	<div class="row">
 		<div class="col-sm-12">
-			Current Status is <b>{{status}}</b> - Set status to 
+			Current Status is <b>{{status}}</b> - Set status to
 			{{#each statuses}}
 				{{#unless $eq ../status this}}
 					<button type="button" class="set-status">{{this}}</button>

--- a/client/views/jobs/jobIncludes.js
+++ b/client/views/jobs/jobIncludes.js
@@ -20,6 +20,16 @@ Template.jobStatusToggle.helpers({
   }
 });
 
+Template.jobLabels.helpers({
+  "new": function(){
+    if (this.createdAt < daysAsNew()) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+});
+
 Template.jobStatusToggle.events({
   "click .set-status": function() {
     Jobs.update({

--- a/client/views/jobs/jobSmall.html
+++ b/client/views/jobs/jobSmall.html
@@ -4,10 +4,10 @@
 			<h4>
 				<a href="{{pathFor 'job'}}">{{title}}</a>
 			</h4>
-		</div> 
+		</div>
 		<div class="col-sm-3 text-right">
 			{{>jobLabels}}
-		</div> 
+		</div>
 	</div>
 	<div class="row">
 		<div class="col-sm-3">

--- a/client/views/profiles/profile.html
+++ b/client/views/profiles/profile.html
@@ -12,14 +12,9 @@
 							{{else}}
 								{{> avatar userId=userId size="large"}}
 							{{/if}}
-							
-							{{#if availableForHire}}
-								<br>
-								<span class="label label-primary"><i class="fa fa-rocket"></i> Hire Me</span>
-							{{/if}}
-							{{#if $eq type 'Company'}}
-								<span class="label label-danger"><i class="fa fa-users"></i> Company</span>
-							{{/if}}
+
+							<br>
+							{{>profileLabels}}
 							<hr>
 							<small>
 								{{#if location}}

--- a/client/views/profiles/profileIncludes.html
+++ b/client/views/profiles/profileIncludes.html
@@ -1,0 +1,14 @@
+<template name="profileLabels">
+  <div class="labels">
+    {{#if new}}
+      <span class="label label-warning"><i class="fa fa-star"></i> New</span>
+    {{/if}}
+    {{#if availableForHire}}
+      <span class="label label-primary"><i class="fa fa-rocket"></i> Hire Me</span>
+    {{/if}}
+    {{#if $eq type 'Company'}}
+      <span class="label label-danger"><i class="fa fa-users"></i> Company</span>
+    {{/if}}
+
+  </div>
+</template>

--- a/client/views/profiles/profileIncludes.js
+++ b/client/views/profiles/profileIncludes.js
@@ -1,0 +1,9 @@
+Template.profileLabels.helpers({
+  "new": function(){
+    if (this.createdAt < daysAsNew()) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+});

--- a/client/views/profiles/profileSmall.html
+++ b/client/views/profiles/profileSmall.html
@@ -12,15 +12,7 @@
 					{{/if}}
 				</a>
 				<h4 class="name"><a href="{{pathFor 'profile'}}">{{displayName}}</a></h4>
-				<div class="labels">
-					{{#if availableForHire}}
-						<span class="label label-primary"><i class="fa fa-rocket"></i> Hire Me</span>
-					{{/if}}
-					{{#if $eq type 'Company'}}
-						<span class="label label-danger"><i class="fa fa-users"></i> Company</span>
-					{{/if}}
-
-				</div>
+				{{>profileLabels}}
 				<div class="title">
 					<small>{{title}}</small>
 				</div>
@@ -29,7 +21,7 @@
 						<small><i class="fa fa-map-marker"></i>&nbsp;{{location}}</small>
 					{{/if}}
 				</div>
-				
+
 			</div>
 		</div>
 	</div>

--- a/collections/jobs.js
+++ b/collections/jobs.js
@@ -31,6 +31,16 @@ Jobs.attachSchema(
       label: "Contact Info",
       max: 128
     },
+    salary: {
+      type: String,
+      label: "Salary",
+      max: 128
+    },
+    equity: {
+      type: String,
+      label: "Equity",
+      max: 128
+    },
     jobtype: {
       type: String,
       label: "Job Type",

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,4 +1,4 @@
-JOB_TYPES = ["Full Time", "Hourly Contract", "Term Contract", "Mentoring", "Bounty", "Open Source", "Volunteer", "Other"];
+JOB_TYPES = ["Full Time", "Hourly Contract", "Term Contract", "Mentoring", "Bounty", "Open Source", "Volunteer", "Co-founder", "Other"];
 
 SUMMERNOTE_OPTIONS = {
   type: 'summernote',

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -36,4 +36,10 @@ daysUntilExpiration = function() {
     var daysAgo = new Date();
     daysAgo.setDate(daysAgo.getDate()-daysToWait);
     return daysAgo;
-}
+};
+
+daysAsNew = function() {
+		var result = new Date();
+    result.setDate(result.getDate() + 7);
+    return result;
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -40,6 +40,6 @@ daysUntilExpiration = function() {
 
 daysAsNew = function() {
 		var result = new Date();
-    result.setDate(result.getDate() + 7);
+    result.setDate(result.getDate() - 7);
     return result;
 };


### PR DESCRIPTION
- Adds the 'New' badge to newly posted jobs and devs. It uses label-warning (yellow) and fa-star icon. Both check against lib/helpers.js daysAsNew() function through their template helpers. Separate concerns creating profileIncludes.html and profileIncludes.js. [Add 'New' badge to newly posted jobs/devs issue](https://github.com/nate-strauser/wework/issues/32)
- Adds job salary and equity fields [Add job salary and equity fields issue](https://github.com/nate-strauser/wework/issues/30)
- Add co-founder to constants.js [Add 'co-founder' as job/interest type issue](https://github.com/nate-strauser/wework/issues/57)
