### PR TITLE
Small typo change in form

### DIFF
--- a/client/views/profiles/profileForms.html
+++ b/client/views/profiles/profileForms.html
@@ -82,7 +82,7 @@
 	{{>afQuickField name='url' placeholder="URL your personal website/blog"}}
 	{{>afQuickField name='resumeUrl' placeholder="URL of resume/cv hosted externally (dropbox, gdrive, etc)"}}
 	{{>afQuickField name='githubUrl' placeholder="Your github public profile"}}
-	{{>afQuickField name='linkedinUrl' placeholder="Your linkeding public profile"}}
+	{{>afQuickField name='linkedinUrl' placeholder="Your linkedin public profile"}}
 	{{>afQuickField name='stackoverflowUrl' placeholder="Your stackoverflow public profile"}}
 	{{>afQuickField name='description' rows=8  placeholder="Tell us about what you've done with meteor, how long you've been programming, things like that"}}
 </template>


### PR DESCRIPTION
I was signing up for meteor.engineer when I saw that **Linkedin** was misspelled as **Linkeding** , so edited it.
![screenshot from 2015-07-22 03 20 46](https://cloud.githubusercontent.com/assets/1131610/8813508/bb6966aa-3021-11e5-8f69-8b27864e07fe.png)
