### PR TITLE
Smaller window profile problem.

### DIFF
--- a/client/views/profiles/profile.html
+++ b/client/views/profiles/profile.html
@@ -63,20 +63,26 @@
 						</div>
 						<div class="col-sm-9">
 							<div class="row">
-								<h2 class="top-flush">
-									{{displayName}}
-								</h2>
+								<div class="col-sm-12">
+									<h2 class="top-flush">
+										{{displayName}}
+									</h2>
+								</div>
 							</div>
 							<div class="row">
-								<h4>
-									{{title}}
-								</h4>
+								<div class="col-sm-12">
+									<h4>
+										{{title}}
+									</h4>
+								</div>
 							</div>
 							<div class="row">
-								{{#if htmlDescription}}
-									<hr>
-									{{{htmlDescription}}}
-								{{/if}}
+								<div class="col-sm-12">
+									{{#if htmlDescription}}
+										<hr>
+										{{{htmlDescription}}}
+									{{/if}}
+								</div>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
Just a small typography bug. When we go to smaller screens there's no padding between the content and container. Reason behind this is absence of `<div class ="col-*-*>` inside `<div class="row">`. So I have added few extra divs to make sure there's padding even at smaller screens. 

![screenshot from 2015-07-22 03 55 49](https://cloud.githubusercontent.com/assets/1131610/8814005/9b04c932-3025-11e5-8203-400a381a207c.png)
