### PR TITLE
Fix job url on small screens

### DIFF
--- a/client/views/jobs/job.html
+++ b/client/views/jobs/job.html
@@ -27,7 +27,7 @@
 								<i class="fa fa-map-marker"></i> {{location}}
 							{{/if}}
 						</div>
-						<div class="col-sm-6 text-right">
+						<div class="col-sm-6 job-url">
 							{{#if url}}
 								<i class="fa fa-external-link fa-m"></i>&nbsp;&nbsp;<a href="{{url}}" target="_blank">{{url}}</a>
 							{{/if}}

--- a/client/views/main.less
+++ b/client/views/main.less
@@ -12,6 +12,14 @@ h1,h2,h3,h4,h5{
     a:not(.btn):visited {
         color: @text-color;
     }
+
+    .job-url {
+        word-break: break-all;
+
+        @media (min-width: @screen-sm-min) {
+            text-align: right;
+        }
+    }
 }
 
 #iron-router-progress {


### PR DESCRIPTION
This PR prevents the layout from making horizontal scrollbars on medium and small screen sizes when there is large urls on the job item page, like this: http://www.weworkmeteor.com/jobs/PqCN8Ybx9SWYzLe3G/front-end-developer

<img width="762" alt="screen shot 2016-01-17 at 8 50 20 pm" src="https://cloud.githubusercontent.com/assets/230893/12380543/727168da-bd5c-11e5-8a20-e0508e51bea6.png">
