### PR TITLE
job type filter in jobs page

### DIFF
--- a/client/views/jobs/jobs.html
+++ b/client/views/jobs/jobs.html
@@ -1,7 +1,25 @@
 <template name="jobs">
-	{{#each jobs}}
-		{{>jobSmall}}
-	{{/each}}
+  <div class="row search-filter">
+    <div class="col-md-3 col-md-offset-9 col-sm-6 text-right">
+      <div class="form-group">
+        <select id="jobType" class="form-control">
+          <option value="All">All</option>
+          {{#each JOB_TYPES}}
+            <option value="{{this}}">{{this}}</option>
+          {{/each}}
+        </select>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    {{#if jobs}}
+    	{{#each jobs}}
+    		{{>jobSmall}}
+    	{{/each}}
+    {{else}}
+      <p class="text-center">No jobs under this category.</p>
+    {{/if}}
+  </div>
 	<div class="text-center">
 		{{> infiniteScroll }}
 	</div>

--- a/client/views/jobs/jobs.js
+++ b/client/views/jobs/jobs.js
@@ -1,19 +1,45 @@
 Template.jobs.onCreated(function() {
+  this.query = new ReactiveVar({});
   this.infiniteScroll({
     perPage: 30,
     subManager: subs,
     collection: Jobs,
-    publication: 'jobs'
+    publication: 'jobs',
+    query: this.query
   });
 });
 
 Template.jobs.helpers({
   "jobs": function() {
-    return Jobs.find({}, {
+
+    var query = Template.instance().query.get();
+    var options = {
       sort: {
         featuredThrough: -1,
         createdAt: -1
       }
-    });
+    };
+
+    let jobs = Jobs.find(query, options);
+
+    if(jobs.count() > 0){
+      return jobs;
+    }
+
+    return false;
+  },
+  "JOB_TYPES": function() {
+    return JOB_TYPES;
   }
 })
+
+Template.jobs.events({
+  'change #jobType': function (event, template) {
+    let type = event.currentTarget.value;
+    if(type === "All") {
+      template.query.set({})
+    }else{
+      template.query.set({jobtype: type})
+    }
+  }
+});


### PR DESCRIPTION
Added simple filter in /jobs page based on the existing one in /profiles page.

Check Below GIF
[
http://g.recordit.co/62F4BcveYR.gif
![1](https://cloud.githubusercontent.com/assets/6153816/20570527/f8585fbe-b1c9-11e6-9528-f02d4dda06f2.gif)
](url)

I want to add more features like

- Clicking on the label in job post automatically selects label from dropdown and filter the values.

Just want to know you wanted this features.


